### PR TITLE
Use SSG for page rendering

### DIFF
--- a/src/lib/fetch-all-movies.ts
+++ b/src/lib/fetch-all-movies.ts
@@ -1,0 +1,16 @@
+import { MovieData } from "@/types";
+
+export default async function fetchAllMovies(): Promise<MovieData[]> {
+  const url = `http://localhost:12345/movie`;
+
+  try {
+    const res = await fetch(url);
+    if (!res.ok) {
+      throw new Error("Failed to fetch movies");
+    }
+    return await res.json();
+  } catch (error) {
+    console.error(error);
+    return [];
+  }
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,11 +2,11 @@ import SearchableLayout from "@/components/searchable-layout";
 import { ReactNode } from "react";
 import MovieCard from "@/components/movie-card";
 import styles from "./index.module.css";
-import { InferGetServerSidePropsType } from "next";
+import { InferGetServerSidePropsType, InferGetStaticPropsType } from "next";
 import fetchMovies from "@/lib/fetch-movies";
 import fetchRandomMovies from "@/lib/fetch-random-movies";
 
-export const getServerSideProps = async () => {
+export const getStaticProps = async () => {
   const [allMovies, recommendMovies] = await Promise.all([
     fetchMovies(),
     fetchRandomMovies(),
@@ -23,7 +23,7 @@ export const getServerSideProps = async () => {
 export default function Home({
   allMovies,
   recommendMovies,
-}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+}: InferGetStaticPropsType<typeof getStaticProps>) {
   return (
     <>
       <section className={styles.section}>

--- a/src/pages/movie/[id].tsx
+++ b/src/pages/movie/[id].tsx
@@ -3,10 +3,17 @@ import styles from "./[id].module.css";
 import { GetStaticPropsContext, InferGetStaticPropsType } from "next";
 import fetchMovie from "@/lib/fetch-movie";
 import { useRouter } from "next/router";
+import fetchAllMovies from "@/lib/fetch-all-movies";
 
 export const getStaticPaths = async () => {
+  const res = await fetchAllMovies();
+
+  const movieIds = res.map((movie) => ({
+    params: { id: movie.id.toString() },
+  }));
+
   return {
-    paths: [],
+    paths: movieIds,
     fallback: true,
   };
 };

--- a/src/pages/movie/[id].tsx
+++ b/src/pages/movie/[id].tsx
@@ -1,15 +1,26 @@
 import Image from "next/image";
 import styles from "./[id].module.css";
-import { GetServerSidePropsContext } from "next";
+import { GetStaticPropsContext, InferGetStaticPropsType } from "next";
 import fetchMovie from "@/lib/fetch-movie";
-import { MovieData } from "@/types";
+import { useRouter } from "next/router";
 
-export const getServerSideProps = async (
-  context: GetServerSidePropsContext
-) => {
+export const getStaticPaths = async () => {
+  return {
+    paths: [],
+    fallback: true,
+  };
+};
+
+export const getStaticProps = async (context: GetStaticPropsContext) => {
   const id = context.params?.id;
 
   const movie = await fetchMovie(Number(id));
+
+  if (!movie) {
+    return {
+      notFound: true,
+    };
+  }
 
   return {
     props: {
@@ -17,7 +28,16 @@ export const getServerSideProps = async (
     },
   };
 };
-export default function MovieDetail({ movie }: { movie: MovieData }) {
+
+export default function MovieDetail({
+  movie,
+}: InferGetStaticPropsType<typeof getStaticProps>) {
+  const router = useRouter();
+
+  if (router.isFallback) return "로딩중입니다";
+
+  if (!movie) return "문제가 발생했습니다. 다시 시도해주세요.";
+
   const {
     title,
     releaseDate,

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -1,34 +1,30 @@
 import SearchableLayout from "@/components/searchable-layout";
 import { useRouter } from "next/router";
-import { ReactNode } from "react";
+import { ReactNode, useEffect, useState } from "react";
 import MovieCard from "@/components/movie-card";
 import styles from "./index.module.css";
-import { GetServerSidePropsContext, InferGetServerSidePropsType } from "next";
 import fetchMovies from "@/lib/fetch-movies";
+import { MovieData } from "@/types";
 
-export const getServerSideProps = async (
-  context: GetServerSidePropsContext
-) => {
-  const q = context.query.q;
-
-  const movies = await fetchMovies(q as string);
-
-  return {
-    props: {
-      movies,
-    },
-  };
-};
-
-export default function Search({
-  movies,
-}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+export default function Search() {
+  const [movies, setMovies] = useState<MovieData[]>([]);
   const router = useRouter();
-  const { q } = router.query;
+  const q = router.query.q;
+
+  const fetchSearchResult = async () => {
+    const res = await fetchMovies(q as string);
+    setMovies(res);
+  };
+
+  useEffect(() => {
+    if (!q) return;
+
+    fetchSearchResult();
+  }, [q]);
 
   return (
     <section className={styles.section}>
-      <h2>검색 결과: {`"${q}"`}</h2>
+      <h2>검색 결과: {`"${q || ""}"`}</h2>
       <div className={styles.searchResultList}>
         {movies.map((movie) => (
           <MovieCard key={movie.id} {...movie} />


### PR DESCRIPTION
#3 

Use SSG for following pages:

1. Index page
- No real-time data used
- Can show page contents to fist-time users quickly by showing the pre-generated page at build time.
2. Search page
- Render page layout by SSG
- Components related to the search results are rendered by CSR since the search results based on the user's input need to be requested from the browser side
3. Movie page
- Movie information data unlikely to be updated
- Use `getStaticPaths` and pre-generate related all dynamic route pages
  - Use `fallback: true` option to handle fallback for paths that are not pre-generated

---

다음의 페이지에 SSG를 적용하였습니다 :

1. 인덱스 페이지
- 실시간 데이터를 사용하지 않고, 페이지에 사용되는 데이터가 자주 바뀌지 않을 가능성이 크므로 SSG로 충분하다고 판단됨
- 빌드 시 미리 생성한 페이지를 보여줌으로써 사용자의 최초 진입 때부터 빠르게 컨텐츠 제공 가능
2. 검색 페이지
- 사용자의 입력값에 따른 검색 결과를 브라우저 측에서 요청해야하므로 관련 렌더링 로직은 CSR로 처리하고 페이지 레이아웃은 SSG로 렌더링
3. 영화 상세 페이지
- 영화 정보 데이터가 업데이트될 가능성이 크지 않다는 판단하에 SSG 적용
- 동적 router에 `getStaticPaths` 사용하여 관련 경로의 모든 페이지 사전 렌더링
  - `fallback: true` 옵션 사용하여 사전에 생성되어있지 않은 경로에 대한 fallback 처리