### PR TITLE
Feat: Render movie data fetching from API / Data Cache

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,6 +3,16 @@ const nextConfig = {
   images: {
     remotePatterns: [{ hostname: "media.themoviedb.org" }],
   },
+  logging: {
+    fetches: {
+      fullUrl: true,
+    },
+  },
+  compiler: {
+    removeConsole: process.env.NODE_ENV === "production" && {
+      exclude: ["error"],
+    },
+  },
 };
 
 export default nextConfig;

--- a/src/app/(with-searchbar)/page.tsx
+++ b/src/app/(with-searchbar)/page.tsx
@@ -1,25 +1,52 @@
 import { css, cva } from "../../../styled-system/css";
-import mockData from "./../mock/dummy.json";
+import { MovieData } from "../type";
 import MovieCard from "./components/MovieCard";
+
+async function AllMovies() {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_API_SERVER_URL}/movie`, {
+    cache: "force-cache",
+  });
+  const movieData = await res.json();
+
+  if (!res.ok) return "데이터를 불러오는 중 오류가 발생했습니다...";
+
+  return (
+    <div className={containerRecipe({ column: "5" })}>
+      {movieData.map((data: MovieData) => (
+        <MovieCard key={data.id} {...data} />
+      ))}
+    </div>
+  );
+}
+
+async function RecommendedMovies() {
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_API_SERVER_URL}/movie/random`,
+    { next: { revalidate: 3 } }
+  );
+  const movieData = await res.json();
+
+  if (!res.ok) return "데이터를 불러오는 중 오류가 발생했습니다...";
+
+  return (
+    <div className={containerRecipe({ column: "3" })}>
+      {movieData.map((data: MovieData) => (
+        <MovieCard key={data.id} {...data} />
+      ))}
+    </div>
+  );
+}
 
 export default function Home() {
   return (
     <>
       <section>
         <h2 className={headingStyle}>지금 가장 추천하는 영화</h2>
-        <div className={containerRecipe({ column: "3" })}>
-          {mockData.slice(0, 3).map((data) => (
-            <MovieCard key={data.id} {...data} />
-          ))}
-        </div>
+        <RecommendedMovies />
       </section>
       <section>
         <h2 className={headingStyle}>등록된 모든 영화</h2>
-        <div className={containerRecipe({ column: "5" })}>
-          {mockData.map((data) => (
-            <MovieCard key={data.id} {...data} />
-          ))}
-        </div>
+        <AllMovies />
       </section>
     </>
   );

--- a/src/app/(with-searchbar)/search/page.tsx
+++ b/src/app/(with-searchbar)/search/page.tsx
@@ -1,21 +1,26 @@
 import { css } from "../../../../styled-system/css";
 import MovieCard from "../components/MovieCard";
-import mockData from "./../../mock/dummy.json";
+import { MovieData } from "@/app/type";
 
 interface IProps {
   searchParams: {
-    q?: string;
+    q: string;
   };
 }
 
-export default function Page({ searchParams }: IProps) {
+export default async function Page({ searchParams: { q } }: IProps) {
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_API_SERVER_URL}/movie/search?q=${q}`
+  );
+  const searchResults = await res.json();
+
   return (
     <section className={css({ marginTop: "5" })}>
       <h2 className={css({ fontSize: "24px", fontWeight: 800 })}>
-        검색결과: {searchParams.q || ""}
+        검색결과: {q || ""}
       </h2>
       <div className={containerStyle}>
-        {mockData.slice(0, 1).map((data) => (
+        {searchResults.map((data: MovieData) => (
           <MovieCard key={data.id} {...data} />
         ))}
       </div>

--- a/src/app/movie/[id]/page.tsx
+++ b/src/app/movie/[id]/page.tsx
@@ -1,6 +1,5 @@
 import Image from "next/image";
 import { css } from "../../../../styled-system/css";
-import mockData from "./../../mock/dummy.json";
 
 interface IProps {
   params: {
@@ -8,7 +7,13 @@ interface IProps {
   };
 }
 
-export default function Page({ params }: IProps) {
+export default async function Page({ params }: IProps) {
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_API_SERVER_URL}/movie/${params.id}`,
+    { cache: "force-cache" }
+  );
+  const movieData = await res.json();
+
   const {
     title,
     releaseDate,
@@ -18,7 +23,7 @@ export default function Page({ params }: IProps) {
     description,
     runtime,
     posterImgUrl,
-  } = mockData[0];
+  } = movieData;
 
   return (
     <>


### PR DESCRIPTION
## Data cache
Use data cache option when fetching data

### Index page

**`GET` `/movie/random`** 
Data cache option: `{next: {revalidate: 3}}`
Set to revalidate every 3 seconds to show new movie recommendations frequently

**`GET` `/movie`** 
Data cache option: `force-cache`
As most movie data is unlikely to be updated frequently once registered, set to `force-cache`. However, considering the possible future database updates, if there is cache revalidation option based on database updates, the cache option will be updated accordingly.

### Search page

**`GET` `/movie/search?q={q}`**
No cache since the page should render the data per clienent's request.

### Movie detail page

**`GET` `/movie/{id}`**
Data cache option: `force-cache`
Same reason as the index page

---

## Data cache
Data fetch 시 상황에 맞는 cache option을 사용하였습니다

### Index page

추천영화 데이터 **`GET` `/movie/random`** 
Data cache option: `{next: {revalidate: 3}}`
짧은 주기로 새로운 추천영화를 노출시키기 위해 3초간격으로 revalidate 되도록 설정

등록된 모든 영화 데이터  **`GET` `/movie`** 
Data cache option: `force-cache`
한번 등록된 대부분의 영화 데이터의 경우 자주 업데이트 되지 않을 가능성이 크므로 일단 영구 cache 하도록 설정하였으나 새로운 데이터 추가 혹은 기존 데이터 수정 등의 DB 업데이트시 revalidate 되도록 하는 방법이 있다면 그 방법을 사용하는것이 좋을듯하다

### Search page

검색 결과 데이터 **`GET` `/movie/search?q={q}`**
사용자의 입력값에 따라 데이터를 보여줘야하므로 cache 하지 않음

### Movie detail page

영화 상세 데이터 **`GET` `/movie/{id}`**
Data cache option: `force-cache`
Index page의 이유와 동일
